### PR TITLE
Rename all baseType parameter names to sourceType.

### DIFF
--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/ScrollableTrait.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/ScrollableTrait.kt
@@ -27,10 +27,10 @@ class ScrollableTrait : Trait {
             type: TypeSpec.Builder,
             initMethod: MethodSpec.Builder,
             rClass: ClassName,
-            baseType: String) {
+            sourceType: String) {
 
         // ScrollView overrides
-        if (baseType.contains("ScrollView")) {
+        if (sourceType.contains("ScrollView")) {
             addRxBindingApiForSettable(type, SettableApi(
                     RxBindingInfo(RxTypeNames.Rx.RxNestedScrollView,
                             "scrollChangeEvents",
@@ -42,11 +42,11 @@ class ScrollableTrait : Trait {
                     MethodSpec.methodBuilder("accept")
                             .addModifiers(Modifier.PUBLIC)
                             .addParameter(RxTypeNames.Rx.ViewScrollChangeEvent, "event")
-                            .addStatement("l.onScrollChange($baseType.this, event.scrollX(), event.scrollY(), event.oldScrollX(), event.oldScrollY())")))
+                            .addStatement("l.onScrollChange($sourceType.this, event.scrollX(), event.scrollY(), event.oldScrollX(), event.oldScrollY())")))
         }
 
         // RecyclerView overrides
-        if (baseType.contains("RecyclerView")) {
+        if (sourceType.contains("RecyclerView")) {
             addRxBindingApiForAdditive(type, AdditiveApi(
                     RxBindingInfo(RxTypeNames.Rx.RxRecyclerView,
                             "scrollEvents",

--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/TextInputTrait.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/TextInputTrait.kt
@@ -26,7 +26,7 @@ class TextInputTrait : Trait {
             type: TypeSpec.Builder,
             initMethod: MethodSpec.Builder,
             rClass: ClassName,
-            baseType: String) {
+            sourceType: String) {
 
         // TextChanges
         addRxBindingApiForAdditive(type, AdditiveApi(

--- a/artist-traits/src/main/kotlin/com/uber/artist/traits/ForegroundTrait.kt
+++ b/artist-traits/src/main/kotlin/com/uber/artist/traits/ForegroundTrait.kt
@@ -44,9 +44,9 @@ class ForegroundTrait : Trait {
             type: TypeSpec.Builder,
             initMethod: MethodSpec.Builder,
             rClass: ClassName,
-            baseType: String) {
+            sourceType: String) {
 
-        val isLayout = baseType.endsWith("Layout")
+        val isLayout = sourceType.endsWith("Layout")
 
         // The field
         type.addField(TypeNames.Android.Drawable, "foreground", Modifier.PRIVATE)
@@ -115,7 +115,7 @@ class ForegroundTrait : Trait {
 
         type.addMethod(onSizeChangedMethod.build())
 
-        if (baseType.endsWith("ImageView")) {
+        if (sourceType.endsWith("ImageView")) {
             type.addMethod(MethodSpec.methodBuilder("hasOverlappingRendering")
                     .addAnnotation(Override::class.java)
                     .addModifiers(Modifier.PUBLIC)

--- a/artist-traits/src/main/kotlin/com/uber/artist/traits/VisibilityTrait.kt
+++ b/artist-traits/src/main/kotlin/com/uber/artist/traits/VisibilityTrait.kt
@@ -13,7 +13,7 @@ class VisibilityTrait : Trait {
         type: Builder,
         initMethod: MethodSpec.Builder,
         rClass: ClassName,
-        baseType: String) {
+        sourceType: String) {
 
         // Visibility convenience methods
         arrayOf("visible", "invisible", "gone")


### PR DESCRIPTION
Kotlin likes to have the same names and complains if they're not the same.