### PR TITLE
Update Gradle repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ subprojects { subproject ->
     if (subproject.buildFile.exists()) {
         repositories {
             jcenter()
-            mavenCentral()
+            google()
         }
 
         rootProject.dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,8 @@ buildscript {
     apply from: project.file('gradle/dependencies.gradle')
 
     repositories {
-        maven { url 'https://maven.google.com' }
         jcenter()
-        mavenCentral()
+        google()
         maven { url deps.build.gradlePluginsUrl }
     }
 
@@ -34,8 +33,8 @@ apply from: project.file('gradle/dependencies.gradle')
 subprojects {
     buildscript {
         repositories {
-            maven { url 'https://maven.google.com' }
             jcenter()
+            google()
         }
     }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,9 +2,9 @@ buildscript {
     apply from: project.rootProject.file("../gradle/dependencies.gradle")
 
     repositories {
-        maven { url 'https://maven.google.com' }
         jcenter()
-        mavenCentral()
+        google()
+        maven { url deps.build.gradlePluginsUrl }
     }
 
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 apply from: project.rootProject.file("../gradle/dependencies.gradle")
 repositories {
     jcenter()
-    mavenCentral()
+    google()
 }
 
 subprojects { subproject ->
@@ -24,7 +24,7 @@ subprojects { subproject ->
         apply from: project.rootProject.file("../gradle/dependencies.gradle")
         repositories {
             jcenter()
-            mavenCentral()
+            google()
         }
 
         rootProject.dependencies {


### PR DESCRIPTION
When I went to pick up a snapshot build, I noticed that Travis CI had stopped running on PRs and master commits. This fixes the Travis CI build by adding the `google()` repo and using `jcenter()` instead of `mavenCentral()`.