### PR TITLE
Split RxConfig API into Java and Kotlin pieces

### DIFF
--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/ApiHelper.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/ApiHelper.kt
@@ -25,7 +25,7 @@ import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
 import com.uber.artist.api.TypeNames
-import com.uber.artist.traits.rx.config.ArtistRxConfigService
+import com.uber.artist.traits.rx.config.JavaArtistRxConfigService
 import javax.lang.model.element.Modifier
 
 data class RxBindingInfo(
@@ -53,12 +53,12 @@ data class AdditiveApi(
 )
 
 fun TypeName.irrelevantIfObject(): TypeName {
-    val artistRxConfig = ArtistRxConfigService.newInstance().getArtistRxConfig()
+    val artistRxConfig = JavaArtistRxConfigService.newInstance().getArtistRxConfig()
     return if (this == TypeName.OBJECT.box()) artistRxConfig.rxBindingSignalEventTypeName() else this
 }
 
 fun addRxBindingApiForAdditive(type: TypeSpec.Builder, api: AdditiveApi) {
-    val artistRxConfig = ArtistRxConfigService.newInstance().getArtistRxConfig()
+    val artistRxConfig = JavaArtistRxConfigService.newInstance().getArtistRxConfig()
     type.addMethod(MethodSpec.methodBuilder(api.rxBindingInfo.methodName)
             .addJavadoc("${api.rxBindingInfo.methodDoc}\n")
             .apply {
@@ -85,7 +85,7 @@ fun addRxBindingApiForAdditive(type: TypeSpec.Builder, api: AdditiveApi) {
 }
 
 fun addRxBindingApiForSettable(type: TypeSpec.Builder, api: SettableApi, isDebug: Boolean = true) {
-    val artistRxConfig = ArtistRxConfigService.newInstance().getArtistRxConfig()
+    val artistRxConfig = JavaArtistRxConfigService.newInstance().getArtistRxConfig()
     val rxBindingClassName = api.rxBindingInfo.className
     val rxBindingMethod = api.rxBindingInfo.methodName
     val rxBindingMethodDoc = api.rxBindingInfo.methodDoc

--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/ViewTrait.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/ViewTrait.kt
@@ -25,11 +25,12 @@ import com.uber.artist.api.JavaTrait
 import com.uber.artist.api.Trait
 import com.uber.artist.api.TypeNames
 import com.uber.artist.traits.rx.config.ArtistRxConfigService
+import com.uber.artist.traits.rx.config.JavaArtistRxConfigService
 import javax.lang.model.element.Modifier
 
 @AutoService(JavaTrait::class)
 open class ViewTrait : JavaTrait {
-    private val artistRxConfig by lazy { ArtistRxConfigService.newInstance().getArtistRxConfig() }
+    private val artistRxConfig by lazy { JavaArtistRxConfigService.newInstance().getArtistRxConfig() }
 
     override fun generateFor(
             type: TypeSpec.Builder,

--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/ArtistRxConfig.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/ArtistRxConfig.kt
@@ -16,43 +16,41 @@
 
 package com.uber.artist.traits.rx.config
 
-import com.squareup.javapoet.CodeBlock
-import com.squareup.javapoet.TypeName
 
 /**
  * This configuration object describes various plugin points for rx-based traits.
  */
-abstract class ArtistRxConfig {
+interface ArtistRxConfig<CodeBlockType, TypeNameType> {
 
     /**
      * Plugin point for generating additional code to invoke when a view has been tapped.
      */
-    open fun processTap(codeBlockBuilder: CodeBlock.Builder) { }
+    fun processTap(codeBlockBuilder: CodeBlockType) { }
 
     /**
      * Plugin point for generating additional code to invoke when a view has attached to the window.
      */
-    open fun processImpression(codeBlockBuilder: CodeBlock.Builder) { }
+    fun processImpression(codeBlockBuilder: CodeBlockType) { }
 
     /**
      * Plugin point for generating additional code to invoke when a view has changed visibility.
      */
-    open fun processVisibilityChanges(codeBlockBuilder: CodeBlock.Builder) { }
+    fun processVisibilityChanges(codeBlockBuilder: CodeBlockType) { }
 
     /**
      * Plugin point for generating additional code to modify an RxBinding stream.
      */
-    open fun processRxBindingStream(codeBlockBuilder: CodeBlock.Builder, streamTypeName: TypeName) { }
+    fun processRxBindingStream(codeBlockBuilder: CodeBlockType, streamTypeName: TypeNameType) { }
 
     /**
      * Plugin point for generating additional code to modify an RxBinding stream which notifies that something occurred.
      * This can be used along with rxBindingSignalEventTypeName() to map signal events to a different type.
      */
-    open fun processRxBindingSignalEvent(codeBlockBuilder: CodeBlock.Builder) { }
+    fun processRxBindingSignalEvent(codeBlockBuilder: CodeBlockType) { }
 
     /**
      * This defines the type to be used for RxBinding event signals. It can be changed if processRxBindingSignalEvent()
      * has been overridden to map the signal events to a new type. The default type is Object.
      */
-    open fun rxBindingSignalEventTypeName(): TypeName = TypeName.OBJECT
+    fun rxBindingSignalEventTypeName(): TypeNameType
 }

--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/JavaArtistRxConfig.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/JavaArtistRxConfig.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.artist.traits.rx.config
+
+import com.squareup.javapoet.CodeBlock
+import com.squareup.javapoet.TypeName
+
+/**
+ * This configuration object describes various plugin points for rx-based traits.
+ */
+abstract class JavaArtistRxConfig : ArtistRxConfig<CodeBlock.Builder, TypeName> {
+
+  /**
+   * Plugin point for generating additional code to invoke when a view has been tapped.
+   */
+  override fun processTap(codeBlockBuilder: CodeBlock.Builder) {}
+
+  /**
+   * Plugin point for generating additional code to invoke when a view has attached to the window.
+   */
+  override fun processImpression(codeBlockBuilder: CodeBlock.Builder) {}
+
+  /**
+   * Plugin point for generating additional code to invoke when a view has changed visibility.
+   */
+  override fun processVisibilityChanges(codeBlockBuilder: CodeBlock.Builder) {}
+
+  /**
+   * Plugin point for generating additional code to modify an RxBinding stream.
+   */
+  override fun processRxBindingStream(codeBlockBuilder: CodeBlock.Builder, streamTypeName: TypeName) {}
+
+  /**
+   * Plugin point for generating additional code to modify an RxBinding stream which notifies that something occurred.
+   * This can be used along with rxBindingSignalEventTypeName() to map signal events to a different type.
+   */
+  override fun processRxBindingSignalEvent(codeBlockBuilder: CodeBlock.Builder) {}
+
+  /**
+   * This defines the type to be used for RxBinding event signals. It can be changed if processRxBindingSignalEvent()
+   * has been overridden to map the signal events to a new type. The default type is Object.
+   */
+  override fun rxBindingSignalEventTypeName(): TypeName = TypeName.OBJECT
+}

--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/JavaArtistRxConfigService.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/JavaArtistRxConfigService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017. Uber Technologies
+ * Copyright (C) 2018. Uber Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,22 @@
 
 package com.uber.artist.traits.rx.config
 
-interface ArtistRxConfigService<ArtistRxConfig> {
+import java.util.ServiceLoader
+
+class JavaArtistRxConfigService private constructor() : ArtistRxConfigService<JavaArtistRxConfig> {
+
+    private val serviceLoader = ServiceLoader.load(JavaArtistRxConfig::class.java)
 
     /**
      * Gets the optionally overridden [ArtistRxConfig] implementation or the default.
      *
      * @return The located [ArtistRxConfig] or a default config if not provided.
      */
-    fun getArtistRxConfig(): ArtistRxConfig
+    override fun getArtistRxConfig(): JavaArtistRxConfig = serviceLoader.asIterable().firstOrNull() ?: DEFAULT_CONFIG
+
+    companion object {
+        private val DEFAULT_CONFIG: JavaArtistRxConfig = JavaDefaultArtistRxConfig()
+
+        fun newInstance(): JavaArtistRxConfigService = JavaArtistRxConfigService()
+    }
 }

--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/JavaDefaultArtistRxConfig.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/JavaDefaultArtistRxConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017. Uber Technologies
+ * Copyright (C) 2018. Uber Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 package com.uber.artist.traits.rx.config
 
-class DefaultArtistRxConfig : ArtistRxConfig()
+class JavaDefaultArtistRxConfig : JavaArtistRxConfig()

--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/KotlinArtistRxConfig.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/KotlinArtistRxConfig.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2018. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.artist.traits.rx.config
+
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.UNIT
+
+/**
+ * This configuration object describes various plugin points for rx-based traits.
+ */
+abstract class KotlinArtistRxConfig : ArtistRxConfig<CodeBlock.Builder, TypeName> {
+
+  /**
+   * Plugin point for generating additional code to invoke when a view has been tapped.
+   */
+  override fun processTap(codeBlockBuilder: CodeBlock.Builder) {}
+
+  /**
+   * Plugin point for generating additional code to invoke when a view has attached to the window.
+   */
+  override fun processImpression(codeBlockBuilder: CodeBlock.Builder) {}
+
+  /**
+   * Plugin point for generating additional code to invoke when a view has changed visibility.
+   */
+  override fun processVisibilityChanges(codeBlockBuilder: CodeBlock.Builder) {}
+
+  /**
+   * Plugin point for generating additional code to modify an RxBinding stream.
+   */
+  override fun processRxBindingStream(codeBlockBuilder: CodeBlock.Builder, streamTypeName: TypeName) {}
+
+  /**
+   * Plugin point for generating additional code to modify an RxBinding stream which notifies that something occurred.
+   * This can be used along with rxBindingSignalEventTypeName() to map signal events to a different type.
+   */
+  override fun processRxBindingSignalEvent(codeBlockBuilder: CodeBlock.Builder) {}
+
+  /**
+   * This defines the type to be used for RxBinding event signals. It can be changed if processRxBindingSignalEvent()
+   * has been overridden to map the signal events to a new type. The default type is Object.
+   */
+  override fun rxBindingSignalEventTypeName(): TypeName = UNIT
+}

--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/KotlinArtistRxConfigService.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/KotlinArtistRxConfigService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017. Uber Technologies
+ * Copyright (C) 2018. Uber Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,22 @@
 
 package com.uber.artist.traits.rx.config
 
-interface ArtistRxConfigService<ArtistRxConfig> {
+import java.util.ServiceLoader
+
+class KotlinArtistRxConfigService private constructor() : ArtistRxConfigService<KotlinArtistRxConfig> {
+
+    private val serviceLoader = ServiceLoader.load(KotlinArtistRxConfig::class.java)
 
     /**
      * Gets the optionally overridden [ArtistRxConfig] implementation or the default.
      *
      * @return The located [ArtistRxConfig] or a default config if not provided.
      */
-    fun getArtistRxConfig(): ArtistRxConfig
+    override fun getArtistRxConfig(): KotlinArtistRxConfig = serviceLoader.asIterable().firstOrNull() ?: DEFAULT_CONFIG
+
+    companion object {
+        private val DEFAULT_CONFIG: KotlinArtistRxConfig = KotlinDefaultArtistRxConfig()
+
+        fun newInstance(): KotlinArtistRxConfigService = KotlinArtistRxConfigService()
+    }
 }

--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/KotlinDefaultArtistRxConfig.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/config/KotlinDefaultArtistRxConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017. Uber Technologies
+ * Copyright (C) 2018. Uber Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,4 @@
 
 package com.uber.artist.traits.rx.config
 
-interface ArtistRxConfigService<ArtistRxConfig> {
-
-    /**
-     * Gets the optionally overridden [ArtistRxConfig] implementation or the default.
-     *
-     * @return The located [ArtistRxConfig] or a default config if not provided.
-     */
-    fun getArtistRxConfig(): ArtistRxConfig
-}
+class KotlinDefaultArtistRxConfig : KotlinArtistRxConfig()

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -27,7 +27,7 @@ def androidx = [
 def apt = [
     autoService : "com.google.auto.service:auto-service:1.0-rc4",
     javapoet : "com.squareup:javapoet:1.9.0",
-    kotlinPoet : "com.squareup:kotlinpoet:1.0.0-RC3"
+    kotlinPoet : "com.squareup:kotlinpoet:1.0.0"
 ]
 
 def build = [

--- a/sample/providers/src/main/java/com/uber/artist/myproviders/SampleRxConfig.java
+++ b/sample/providers/src/main/java/com/uber/artist/myproviders/SampleRxConfig.java
@@ -19,15 +19,15 @@ package com.uber.artist.myproviders;
 import com.google.auto.service.AutoService;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.TypeName;
-import com.uber.artist.traits.rx.config.ArtistRxConfig;
+import com.uber.artist.traits.rx.config.JavaArtistRxConfig;
 
 import androidx.annotation.NonNull;
 
 /**
  * Sample Artist RxTrait Config.
  */
-@AutoService(ArtistRxConfig.class)
-public class SampleRxConfig extends ArtistRxConfig {
+@AutoService(JavaArtistRxConfig.class)
+public class SampleRxConfig extends JavaArtistRxConfig {
 
   @Override
   public void processTap(CodeBlock.Builder codeBlockBuilder) {


### PR DESCRIPTION
This is the second PR in a series that will enable us to generate Kotlin views (#25). This PR separates the core Artist RxConfig logic from the language.