### PR TITLE
Implement KotlinArtistCodeGenerator

### DIFF
--- a/artist-core/src/main/kotlin/com/uber/artist/ArtistCodeGenerator.kt
+++ b/artist-core/src/main/kotlin/com/uber/artist/ArtistCodeGenerator.kt
@@ -84,10 +84,6 @@ abstract class ArtistCodeGenerator<
 
   protected abstract fun generateConstructorsFor(stencil: ViewStencilType, type: OutputType, rClass: ClassName)
 
-  protected abstract fun constructorBlock(stencil: ViewStencilType, rClass: ClassName, total: Int, currentIndex: Int): CodeBlock
-
-  protected abstract fun fallthroughConstructorStatement(stencil: ViewStencilType, rClass: ClassName, count: Int): CodeBlock
-
   protected abstract fun superinterface(className: String): ClassName
 
   protected abstract fun writeFile(fileSpec: OutputFileType, outputDir: File)

--- a/artist-core/src/main/kotlin/com/uber/artist/JavaArtistCodeGenerator.kt
+++ b/artist-core/src/main/kotlin/com/uber/artist/JavaArtistCodeGenerator.kt
@@ -153,7 +153,7 @@ class JavaArtistCodeGenerator : ArtistCodeGenerator<JavaFile, TypeSpec.Builder, 
     }
   }
 
-  override fun constructorBlock(stencil: JavaViewStencil, rClass: ClassName, total: Int, currentIndex: Int): CodeBlock {
+  private fun constructorBlock(stencil: JavaViewStencil, rClass: ClassName, total: Int, currentIndex: Int): CodeBlock {
     val builder = CodeBlock.builder()
     if (currentIndex == total || currentIndex == 3) {
       builder.addStatement(superConstructorStatement(currentIndex))
@@ -164,7 +164,7 @@ class JavaArtistCodeGenerator : ArtistCodeGenerator<JavaFile, TypeSpec.Builder, 
     return builder.build()
   }
 
-  override fun fallthroughConstructorStatement(stencil: JavaViewStencil, rClass: ClassName, count: Int): CodeBlock {
+  private fun fallthroughConstructorStatement(stencil: JavaViewStencil, rClass: ClassName, count: Int): CodeBlock {
     when (count) {
       1 -> return CodeBlock.of("this(context, null);\n")
       2 -> {


### PR DESCRIPTION
Implements the core logic of generating the base set of constructors and init method for a ViewStencil.

Produces 3-arg View like this:
```kotlin
class MyButton : AppCompatButton, MyView {
    @JvmOverloads
    constructor(
        context: Context,
        @Nullable attrs: AttributeSet? = null,
        @AttrRes defStyleAttr: Int = R.attr.buttonStyle
    ) : super(context, attrs, defStyleAttr) {
        init(context, attrs, defStyleAttr, 0)
    }

    @CallSuper
    protected fun init(
        context: Context,
        @Nullable attrs: AttributeSet?,
        @AttrRes defStyleAttr: Int,
        @StyleRes defStyleRes: Int
    ) {
    }
}
```

And produces a 4-param View like:
```kotlin
class MyLinearLayout : LinearLayout, MyView {
    @JvmOverloads
    constructor(
        context: Context,
        @Nullable attrs: AttributeSet? = null,
        @AttrRes defStyleAttr: Int = 0
    ) : super(context, attrs, defStyleAttr) {
        init(context, attrs, defStyleAttr, 0)
    }

    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
    constructor(
        context: Context,
        @Nullable attrs: AttributeSet? = null,
        @AttrRes defStyleAttr: Int = 0,
        @StyleRes defStyleRes: Int = 0
    ) : super(context, attrs, defStyleAttr, defStyleRes) {
        init(context, attrs, defStyleAttr, defStyleRes)
    }

    @CallSuper
    protected fun init(
        context: Context,
        @Nullable attrs: AttributeSet?,
        @AttrRes defStyleAttr: Int,
        @StyleRes defStyleRes: Int
    ) {
    }
}
```