### PR TITLE
Only generate views for the variant that is built

### DIFF
--- a/artist/src/main/kotlin/com/uber/artist/ArtistPlugin.kt
+++ b/artist/src/main/kotlin/com/uber/artist/ArtistPlugin.kt
@@ -54,7 +54,6 @@ class ArtistPlugin : Plugin<Project> {
   private fun <T : BaseVariant> configureAndroid(
       project: Project,
       variants: DomainObjectSet<T>) {
-    val generateViews = project.task("generateViews")
     variants.all { variant ->
       val outputDir = resolveVariantOutputDir(project, variant, ARTIST)
       val artistTask = project.tasks.create(
@@ -71,7 +70,6 @@ class ArtistPlugin : Plugin<Project> {
             generateKotlin = artistExtension.generateKotlin
           }
       artistTask.outputs.dir(outputDir)
-      generateViews.dependsOn(artistTask)
 
       variant.registerJavaGeneratingTask(artistTask, artistTask.outputDirectory)
     }


### PR DESCRIPTION
This removes the extra `generateViews` task that depended on generating views for each variant since it is unnecessary and suboptimal for performance.