### PR TITLE
Fix nullable clicks/long clicks relay causing kotlin build failures

### DIFF
--- a/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/KotlinApiHelper.kt
+++ b/artist-traits-rx/src/main/kotlin/com/uber/artist/traits/rx/KotlinApiHelper.kt
@@ -204,6 +204,9 @@ fun addRxBindingApiForSettable(type: TypeSpec.Builder, api: KotlinSettableApi, i
       }
       .addCode(CodeBlock.builder()
           .apply {
+            add("$rxBindingMethod?.let {\n")
+          }
+          .apply {
             if (rx_alias != null) {
               add("$rx_alias()")
             } else {
@@ -218,7 +221,8 @@ fun addRxBindingApiForSettable(type: TypeSpec.Builder, api: KotlinSettableApi, i
               artistRxConfig.processTap(this)
             }
           }
-          .addStatement(".subscribe($rxBindingMethod)")
+          .addStatement(".subscribe(it)")
+          .addStatement(" }\n")
           .build())
       .endControlFlow()
       .addCode(CodeBlock.builder()


### PR DESCRIPTION
Thank you for contributing to Artist. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.

**Description** 
Currently artist generates nullable rx relays that are initialized when a consumer starts listening to the `clicks()` or `longClicks()` function. It internally subscribes to the rxBinding relay but any new changes are causing a build failure. 

We can either use `!!` to force check nullable or like this PR put it inside a `?.let` block. 

This is caused after migration from java to kotlin

Tested locally by building, installing and running through the app